### PR TITLE
[wpmldev-6998] Add explicit nullable type hint in ReflectionCacheApc

### DIFF
--- a/lib/ReflectionCacheApc.php
+++ b/lib/ReflectionCacheApc.php
@@ -7,7 +7,7 @@ class ReflectionCacheApc implements ReflectionCache
     private $localCache;
     private $timeToLive = 5;
 
-    public function __construct(ReflectionCache $localCache = null)
+    public function __construct(?ReflectionCache $localCache = null)
     {
         $this->localCache = $localCache ?: new ReflectionCacheArray;
     }


### PR DESCRIPTION
Prevents the PHP 8.4 "Implicitly marking parameter $localCache as nullable is deprecated" notice in `ReflectionCacheApc::__construct` (line 10).

Prefixing with `?` is byte-compatible with the implicit form and valid PHP 7.1+ (safe across PHP 7.4–8.5).

This class only autoloads when the APCu extension is present, so the deprecation only surfaces on APCu-enabled hosts. Lint-verified locally via `php -l` under PHP 7.4 / 8.3 / 8.4 / 8.5; runtime verification on an APCu host is recommended before merging.

Part of [wpmldev-6998](https://onthegosystems.myjetbrains.com/youtrack/issue/wpmldev-6998) (sibling fixes in `wpml/wpml`, `wpml/sql-parser`, `wpml/fp`).